### PR TITLE
Add npm test placeholder

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         run: npm ci --prefix frontend
+      - name: Test
+        run: npm test --prefix frontend
       - name: Build
         run: npm run build --prefix frontend
       - uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Before each build, the `threat-intel` directory at the repository root is copied
 
 When running `npm run dev --prefix frontend`, the copy step runs automatically via the predev script.
 
+## Testing
+
+At the moment there are no automated tests. The `npm test` command simply
+prints a placeholder message. Run it with:
+
+```bash
+npm test --prefix frontend
+```
+
+This allows the CI workflow to report success until real tests are added.
+
 ## Deployment
 
 Pushing to the `main` branch triggers the GitHub Actions workflow in `.github/workflows/deploy.yml`. The workflow builds the frontend and deploys the `frontend/dist` directory to GitHub Pages.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "echo \"No tests yet\"",
     "preview": "vite preview",
     "copy-data": "rm -rf public/threat-intel && cp -r ../threat-intel public/",
     "prebuild": "npm run copy-data",


### PR DESCRIPTION
## Summary
- add a dummy `npm test` script in `frontend/package.json`
- document the placeholder test command in the README
- run `npm test` in the deploy workflow

## Testing
- `npm ci --prefix frontend`
- `npm run lint --prefix frontend`
- `npm run build --prefix frontend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6884f91fee208327967653925d51ebac