### PR TITLE
Add lint step before build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         run: npm ci --prefix frontend
+      - name: Lint
+        run: npm run lint --prefix frontend
       - name: Build
         run: npm run build --prefix frontend
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- run linting in deploy workflow to catch issues before building

## Testing
- `npm ci --prefix frontend`
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6884f92364148327974762be60dde7fe