### PR TITLE
Fix router basename for GitHub Pages deployment

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- ensure React Router uses the same base path as Vite

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886b163a7588327bd20ccd4da519f02