### PR TITLE
Improve icon accessibility

### DIFF
--- a/src/Pages/Dashboard.tsx
+++ b/src/Pages/Dashboard.tsx
@@ -81,7 +81,7 @@ export default function Dashboard() {
           </div>
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-2 px-4 py-2 bg-green-500/10 text-green-400 rounded-lg border border-green-500/20">
-              <Activity className="w-4 h-4" />
+              <Activity aria-hidden="true" className="w-4 h-4" />
               <span className="font-medium">System Online</span>
             </div>
           </div>

--- a/src/Pages/Export.tsx
+++ b/src/Pages/Export.tsx
@@ -179,7 +179,7 @@ export default function Export() {
           <Card className="cyber-card">
             <CardHeader>
               <CardTitle className="text-white flex items-center gap-2">
-                <Filter className="w-5 h-5" />
+                <Filter aria-hidden="true" className="w-5 h-5" />
                 Export Configuration
               </CardTitle>
             </CardHeader>
@@ -298,7 +298,7 @@ export default function Export() {
           <Card className="cyber-card">
             <CardHeader>
               <CardTitle className="text-white flex items-center gap-2">
-                <Database className="w-5 h-5" />
+                <Database aria-hidden="true" className="w-5 h-5" />
                 Include Fields
               </CardTitle>
             </CardHeader>
@@ -348,7 +348,7 @@ export default function Export() {
                 disabled={filteredData.length === 0 || isLoading}
                 className="bg-gradient-to-r from-green-500 to-emerald-600 text-white hover:from-green-600 hover:to-emerald-700 cyber-glow"
               >
-                <Download className="w-4 h-4 mr-2" />
+                <Download aria-hidden="true" className="w-4 h-4 mr-2" />
                 Export {filteredData.length} Records
               </Button>
             </div>

--- a/src/Pages/IOCs.tsx
+++ b/src/Pages/IOCs.tsx
@@ -134,14 +134,14 @@ export default function IOCs() {
               className="cyber-border hover:bg-cyan-500/10 text-cyan-300 border-cyan-500/50"
               disabled={filteredIocs.length === 0}
             >
-              <Download className="w-4 h-4 mr-2" />
+              <Download aria-hidden="true" className="w-4 h-4 mr-2" />
               Export CSV
             </Button>
             <Button
               onClick={() => setShowAddDialog(true)}
               className="bg-cyan-500 hover:bg-cyan-600 text-white cyber-glow"
             >
-              <Plus className="w-4 h-4 mr-2" />
+              <Plus aria-hidden="true" className="w-4 h-4 mr-2" />
               Add IOC
             </Button>
           </div>
@@ -153,7 +153,7 @@ export default function IOCs() {
         {/* Search and Filters */}
         <div className="flex flex-col lg:flex-row gap-4">
           <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+            <Search aria-hidden="true" className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
             <Input
               placeholder="Search IOCs, descriptions, or sources..."
               value={searchTerm}

--- a/src/Pages/Sources.tsx
+++ b/src/Pages/Sources.tsx
@@ -68,7 +68,7 @@ export default function Sources() {
             onClick={() => setShowAddDialog(true)}
             className="bg-gradient-to-r from-cyan-500 to-blue-600 text-white hover:from-cyan-600 hover:to-blue-700 cyber-glow"
           >
-            <Plus className="w-4 h-4 mr-2" />
+            <Plus aria-hidden="true" className="w-4 h-4 mr-2" />
             Add Source
           </Button>
         </div>
@@ -78,7 +78,7 @@ export default function Sources() {
 
         {/* Search */}
         <div className="relative max-w-md">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 w-4 h-4" />
+          <Search aria-hidden="true" className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 w-4 h-4" />
           <Input
             placeholder="Search sources..."
             value={searchTerm}

--- a/src/components/dashboard/RecentIOCs.tsx
+++ b/src/components/dashboard/RecentIOCs.tsx
@@ -13,16 +13,16 @@ const severityColors = {
 };
 
 const typeIcons = {
-  ip: "🌐",
-  domain: "🏠",
-  url: "🔗",
-  hash_md5: "🔒",
-  hash_sha1: "🔒",
-  hash_sha256: "🔒",
-  email: "📧",
-  file_path: "📁",
-  registry_key: "🗝️",
-  other: "❓"
+  ip: { icon: "🌐", label: "IP" },
+  domain: { icon: "🏠", label: "Domain" },
+  url: { icon: "🔗", label: "URL" },
+  hash_md5: { icon: "🔒", label: "MD5 hash" },
+  hash_sha1: { icon: "🔒", label: "SHA1 hash" },
+  hash_sha256: { icon: "🔒", label: "SHA256 hash" },
+  email: { icon: "📧", label: "Email" },
+  file_path: { icon: "📁", label: "File path" },
+  registry_key: { icon: "🗝️", label: "Registry key" },
+  other: { icon: "❓", label: "Other" }
 };
 
 export default function RecentIOCs({ iocs, isLoading }) {
@@ -30,7 +30,7 @@ export default function RecentIOCs({ iocs, isLoading }) {
     <Card className="cyber-card">
       <CardHeader>
         <CardTitle className="text-white flex items-center gap-2">
-          <Clock className="w-5 h-5 text-cyan-400" />
+          <Clock aria-hidden="true" className="w-5 h-5 text-cyan-400" />
           Recent IOCs
         </CardTitle>
       </CardHeader>
@@ -49,7 +49,7 @@ export default function RecentIOCs({ iocs, isLoading }) {
           </div>
         ) : iocs.length === 0 ? (
           <div className="text-center py-8 text-slate-400">
-            <Shield className="w-12 h-12 mx-auto mb-3 opacity-50" />
+            <Shield aria-hidden="true" className="w-12 h-12 mx-auto mb-3 opacity-50" />
             <p>No IOCs found</p>
             <p className="text-sm">Add some indicators to get started</p>
           </div>
@@ -59,7 +59,14 @@ export default function RecentIOCs({ iocs, isLoading }) {
               <div key={ioc.id} className="flex items-center justify-between p-3 rounded-lg border border-slate-700/50 hover:border-cyan-500/30 transition-colors">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
-                    <span className="text-lg">{typeIcons[ioc.type] || '❓'}</span>
+                    <span className="text-lg">
+                      <span
+                        aria-label={(typeIcons[ioc.type] || typeIcons.other).label}
+                        role="img"
+                      >
+                        {(typeIcons[ioc.type] || typeIcons.other).icon}
+                      </span>
+                    </span>
                     <p className="font-medium text-white truncate">
                       {ioc.indicator.length > 30 ? `${ioc.indicator.substring(0, 30)}...` : ioc.indicator}
                     </p>
@@ -74,7 +81,9 @@ export default function RecentIOCs({ iocs, isLoading }) {
                 </div>
                 <div className="ml-3">
                   <Badge className={`${severityColors[ioc.severity]} border text-xs`}>
-                    {ioc.severity === 'critical' && <AlertTriangle className="w-3 h-3 mr-1" />}
+                    {ioc.severity === 'critical' && (
+                      <AlertTriangle aria-hidden="true" className="w-3 h-3 mr-1" />
+                    )}
                     {ioc.severity}
                   </Badge>
                 </div>

--- a/src/components/dashboard/StatsOverview.tsx
+++ b/src/components/dashboard/StatsOverview.tsx
@@ -25,13 +25,13 @@ const StatCard = ({ title, value, icon: Icon, color, trend, isLoading }) => (
           )}
           {trend && (
             <p className="text-sm text-green-400 mt-2 flex items-center gap-1">
-              <TrendingUp className="w-3 h-3" />
+              <TrendingUp aria-hidden="true" className="w-3 h-3" />
               {trend}
             </p>
           )}
         </div>
         <div className={`p-3 rounded-xl ${color} bg-opacity-20 cyber-glow`}>
-          <Icon className={`w-6 h-6 ${color.replace('bg-', 'text-')}`} />
+          <Icon aria-hidden="true" className={`w-6 h-6 ${color.replace('bg-', 'text-')}`} />
         </div>
       </div>
     </CardContent>

--- a/src/components/dashboard/ThreatTimeline.tsx
+++ b/src/components/dashboard/ThreatTimeline.tsx
@@ -57,7 +57,7 @@ export default function ThreatTimeline({ iocs, isLoading }) {
     <Card className="cyber-card">
       <CardHeader>
         <CardTitle className="text-white flex items-center gap-2">
-          <TrendingUp className="w-5 h-5 text-cyan-400" />
+          <TrendingUp aria-hidden="true" className="w-5 h-5 text-cyan-400" />
           7-Day Threat Timeline
         </CardTitle>
       </CardHeader>

--- a/src/components/dashboard/ThreatTypeChart.tsx
+++ b/src/components/dashboard/ThreatTypeChart.tsx
@@ -55,7 +55,7 @@ export default function ThreatTypeChart({ iocs, isLoading }) {
     <Card className="cyber-card">
       <CardHeader>
         <CardTitle className="text-white flex items-center gap-2">
-          <BarChart3 className="w-5 h-5 text-cyan-400" />
+          <BarChart3 aria-hidden="true" className="w-5 h-5 text-cyan-400" />
           Threat Types Distribution
         </CardTitle>
       </CardHeader>
@@ -67,7 +67,7 @@ export default function ThreatTypeChart({ iocs, isLoading }) {
         ) : total === 0 ? (
           <div className="h-64 flex items-center justify-center text-slate-400">
             <div className="text-center">
-              <BarChart3 className="w-16 h-16 mx-auto mb-4 opacity-50" />
+              <BarChart3 aria-hidden="true" className="w-16 h-16 mx-auto mb-4 opacity-50" />
               <p>No threat data available</p>
               <p className="text-sm">Add some IOCs to see the distribution</p>
             </div>

--- a/src/components/dashboard/TopSources.tsx
+++ b/src/components/dashboard/TopSources.tsx
@@ -20,7 +20,7 @@ export default function TopSources({ sources, isLoading }) {
     <Card className="cyber-card">
       <CardHeader>
         <CardTitle className="text-white flex items-center gap-2">
-          <Globe className="w-5 h-5 text-cyan-400" />
+          <Globe aria-hidden="true" className="w-5 h-5 text-cyan-400" />
           Top Sources
         </CardTitle>
       </CardHeader>
@@ -42,7 +42,7 @@ export default function TopSources({ sources, isLoading }) {
           </div>
         ) : topSources.length === 0 ? (
           <div className="text-center py-8 text-slate-400">
-            <Globe className="w-12 h-12 mx-auto mb-3 opacity-50" />
+            <Globe aria-hidden="true" className="w-12 h-12 mx-auto mb-3 opacity-50" />
             <p>No sources found</p>
             <p className="text-sm">Add some sources to get started</p>
           </div>

--- a/src/components/iocs/IOCStats.tsx
+++ b/src/components/iocs/IOCStats.tsx
@@ -9,7 +9,7 @@ const StatCard = ({ title, value, icon: Icon, color }) => (
         <p className="text-sm text-slate-400">{title}</p>
         <p className="text-2xl font-bold text-white">{value}</p>
       </div>
-      <Icon className="w-8 h-8 text-slate-500" />
+      <Icon aria-hidden="true" className="w-8 h-8 text-slate-500" />
     </CardContent>
   </Card>
 );

--- a/src/components/iocs/IOCTable.tsx
+++ b/src/components/iocs/IOCTable.tsx
@@ -58,8 +58,18 @@ const IOCTableRow = ({ ioc, onIOCUpdate }) => {
       <TableRow className="cyber-border border-b hover:bg-gray-800/50">
         <TableCell className="font-medium text-gray-100 truncate max-w-xs">
           <div className="flex items-center gap-2">
-            <Button variant="ghost" size="icon" className="w-6 h-6" onClick={handleCopy}>
-              {copied ? <Check className="w-4 h-4 text-green-400" /> : <ClipboardCopy className="w-4 h-4 text-gray-400 hover:text-cyan-400" />}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="w-6 h-6"
+              onClick={handleCopy}
+            >
+              {copied ? (
+                <Check aria-hidden="true" className="w-4 h-4 text-green-400" />
+              ) : (
+                <ClipboardCopy aria-hidden="true" className="w-4 h-4 text-gray-400 hover:text-cyan-400" />
+              )}
+              <span className="sr-only">{copied ? 'Copied' : 'Copy indicator'}</span>
             </Button>
             <span>{ioc.indicator}</span>
           </div>
@@ -71,18 +81,18 @@ const IOCTableRow = ({ ioc, onIOCUpdate }) => {
         <TableCell className="text-gray-300">{format(new Date(ioc.created_date), 'MMM dd, yyyy')}</TableCell>
         <TableCell>
           {ioc.is_active ? (
-            <Badge className="bg-green-500/10 text-green-400 border-green-500/20"><ShieldCheck className="w-3 h-3 mr-1" /> Active</Badge>
+          <Badge className="bg-green-500/10 text-green-400 border-green-500/20"><ShieldCheck aria-hidden="true" className="w-3 h-3 mr-1" /> Active</Badge>
           ) : (
-            <Badge className="bg-gray-500/10 text-gray-400 border-gray-500/20"><ShieldOff className="w-3 h-3 mr-1" /> Inactive</Badge>
+          <Badge className="bg-gray-500/10 text-gray-400 border-gray-500/20"><ShieldOff aria-hidden="true" className="w-3 h-3 mr-1" /> Inactive</Badge>
           )}
         </TableCell>
         <TableCell>
           <div className="flex items-center gap-2">
             <Button variant="ghost" size="icon" onClick={() => setEditingIOC(ioc)} className="hover:text-cyan-400">
-              <Pencil className="w-4 h-4" />
+              <Pencil aria-hidden="true" className="w-4 h-4" />
             </Button>
             <Button variant="ghost" size="icon" onClick={handleDelete} disabled={isDeleting} className="hover:text-red-500">
-              <Trash2 className="w-4 h-4" />
+              <Trash2 aria-hidden="true" className="w-4 h-4" />
             </Button>
           </div>
         </TableCell>
@@ -113,7 +123,7 @@ export default function IOCTable({ iocs, isLoading, onIOCUpdate }) {
   if (iocs.length === 0) {
     return (
       <div className="text-center py-16 cyber-card rounded-lg">
-        <AlertTriangle className="w-12 h-12 mx-auto mb-4 text-amber-500" />
+        <AlertTriangle aria-hidden="true" className="w-12 h-12 mx-auto mb-4 text-amber-500" />
         <h3 className="text-xl font-semibold text-gray-100">No IOCs Found</h3>
         <p className="text-gray-400 mt-2">Try adjusting your filters or adding new IOCs.</p>
       </div>

--- a/src/components/sources/SourceStats.tsx
+++ b/src/components/sources/SourceStats.tsx
@@ -9,7 +9,7 @@ const StatCard = ({ title, value, icon: Icon, color }) => (
         <p className="text-sm text-slate-400">{title}</p>
         <p className="text-2xl font-bold text-white">{value}</p>
       </div>
-      <Icon className="w-8 h-8 text-slate-500" />
+      <Icon aria-hidden="true" className="w-8 h-8 text-slate-500" />
     </CardContent>
   </Card>
 );

--- a/src/components/sources/SourceTable.tsx
+++ b/src/components/sources/SourceTable.tsx
@@ -46,18 +46,24 @@ const SourceTableRow = ({ source, onSourceUpdate }) => {
         <TableCell className="text-white font-semibold">{source.ioc_count || 0}</TableCell>
         <TableCell>
           {source.is_active ? (
-            <CheckCircle className="w-5 h-5 text-green-400" />
+            <>
+              <CheckCircle aria-hidden="true" className="w-5 h-5 text-green-400" />
+              <span className="sr-only">Active</span>
+            </>
           ) : (
-            <XCircle className="w-5 h-5 text-slate-500" />
+            <>
+              <XCircle aria-hidden="true" className="w-5 h-5 text-slate-500" />
+              <span className="sr-only">Inactive</span>
+            </>
           )}
         </TableCell>
         <TableCell>
           <div className="flex items-center gap-2">
             <Button variant="ghost" size="icon" onClick={() => setEditingSource(source)} className="hover:text-cyan-400">
-              <Pencil className="w-4 h-4" />
-            </Button>
+              <Pencil aria-hidden="true" className="w-4 h-4" />
+              </Button>
             <Button variant="ghost" size="icon" onClick={handleDelete} disabled={isDeleting} className="hover:text-red-500">
-              <Trash2 className="w-4 h-4" />
+              <Trash2 aria-hidden="true" className="w-4 h-4" />
             </Button>
           </div>
         </TableCell>

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -19,7 +19,7 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <Check className="h-4 w-4" />
+      <Check aria-hidden="true" className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))


### PR DESCRIPTION
## Summary
- add accessible labels for emoji icons in `RecentIOCs`
- hide decorative icons from assistive tech
- supply screen-reader text for icon-only status indicators
- update several pages and components for better accessibility

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6886b5212f988327bbc191c8284867c3